### PR TITLE
Use Object.defineProperty instead of __defineSetter__

### DIFF
--- a/lib/log/nodes.coffee
+++ b/lib/log/nodes.coffee
@@ -158,10 +158,12 @@ Log.Span.prototype = Log.extend new Log.Node,
     siblings = []
     siblings.push(span) while (span = (span || @)[type]) && @isSibling(span)
     siblings
-Log.Span::__defineSetter__ 'line', (line) ->
-  @line.remove(@) if @line
-  @_line = line
-  @line.add(@)
+Object.defineProperty Log.Span::, 'line', {
+  set: (line) ->
+    @line.remove(@) if @line
+    @_line = line
+    @line.add(@)
+}
 Object.defineProperty Log.Span::, 'data', {
   get: () -> { id: @id, type: 'span', text: @text, class: @class}
 }


### PR DESCRIPTION
**defineSetter** is not standardized and not supported in IE. It thus breaks Travis completely in IE. This not only fixes https://github.com/travis-ci/travis-ci/issues/1001 but also ensures that the JavaScript code is standards-compliant.

This basically does the same for setters than #1 did for getters.
