### PR TITLE
Use Object.defineProperty also in lib/log.old and spec/helpers

### DIFF
--- a/lib/log.old/engine/dom.coffee
+++ b/lib/log.old/engine/dom.coffee
@@ -39,14 +39,18 @@ $.extend Log.Dom.Part.prototype,
     delete @engine.parts[@num]
   trigger: ->
     @engine.trigger.apply(@engine, arguments)
-Log.Dom.Part::__defineGetter__ 'prev', ->
-  num  = @num
-  prev = @engine.parts[num -= 1] until prev || num < 0
-  prev
-Log.Dom.Part::__defineGetter__ 'next', ->
-  num  = @num
-  next = @engine.parts[num += 1] until next || num >= @engine.parts.length
-  next
+Object.defineProperty Log.Dom.Part::, 'prev', {
+  get: () ->
+    num  = @num
+    prev = @engine.parts[num -= 1] until prev || num < 0
+    prev
+}
+Object.defineProperty Log.Dom.Part::, 'next', {
+  get: () ->
+    num  = @num
+    next = @engine.parts[num += 1] until next || num >= @engine.parts.length
+    next
+}
 
 
 Log.Dom.Nodes = (part) ->
@@ -63,9 +67,9 @@ $.extend Log.Dom.Nodes.prototype,
     @nodes.splice(node.num, 1)
     @part.remove() if @nodes.length == 0
 
-Log.Dom.Nodes::__defineGetter__ 'length', -> @nodes.length
-Log.Dom.Nodes::__defineGetter__ 'first',  -> @nodes[0]
-Log.Dom.Nodes::__defineGetter__ 'last',   -> @nodes[@nodes.length - 1]
+Object.defineProperty Log.Dom.Nodes::, 'length', { get: () -> @nodes.length }
+Object.defineProperty Log.Dom.Nodes::, 'first',  { get: () -> @nodes[0] }
+Object.defineProperty Log.Dom.Nodes::, 'last',   { get: () -> @nodes[@nodes.length - 1] }
 
 Log.Dom.Node = ->
 $.extend Log.Dom.Node,
@@ -81,16 +85,20 @@ $.extend Log.Dom.Node,
     node.remove() for node in nodes
     node.part.nodes.insert(node) for node in nodes
     console.log document.firstChild.innerHTML.replace(/<\/p>/gm, '</p>\n') + '\n'
-Log.Dom.Node::__defineGetter__ 'prev', ->
-  num = @num
-  # console.log @part
-  # console.log [@id, @num, (@part.nodes.nodes.map (n) -> n.id), @part.prev?.id, @part.prev?.nodes.last]
-  prev = @part.nodes.at(num -= 1) until prev || num < 0
-  prev || @part.prev?.nodes.last
-Log.Dom.Node::__defineGetter__ 'next', ->
-  num = @num
-  next = @part.nodes.at(num += 1) until next || num >= @part.nodes.length
-  next || @part.next?.nodes.first
+Object.defineProperty Log.Dom.Node::, 'prev', {
+  get: () ->
+    num = @num
+    # console.log @part
+    # console.log [@id, @num, (@part.nodes.nodes.map (n) -> n.id), @part.prev?.id, @part.prev?.nodes.last]
+    prev = @part.nodes.at(num -= 1) until prev || num < 0
+    prev || @part.prev?.nodes.last
+}
+Object.defineProperty Log.Dom.Node::, 'next', {
+  get: () ->
+    num = @num
+    next = @part.nodes.at(num += 1) until next || num >= @part.nodes.length
+    next || @part.next?.nodes.first
+}
 
 
 Log.Dom.Fold = (part, num, event, name) ->
@@ -177,19 +185,27 @@ Log.Dom.Paragraph.prototype = $.extend new Log.Dom.Node,
   trigger: ->
     @part.trigger.apply(@part, arguments)
 
-Log.Dom.Paragraph::__defineGetter__ 'id', ->
-  "#{@part.num}-#{@num}"
-Log.Dom.Paragraph::__defineSetter__ 'element', (element) ->
-  child = element.firstChild
-  (span.element = child = child.nextSibling) for span in @spans.content
-Log.Dom.Paragraph::__defineGetter__ 'element', ->
-  @spans.first.element.parentNode
-Log.Dom.Paragraph::__defineGetter__ 'tail', ->
-  parent = @element.parentNode
-  next = @
-  tail = []
-  tail.push(next) while (next = next.next) && !next.fold && next.element?.parentNode == parent
-  tail
+Object.defineProperty Log.Dom.Paragraph::, 'id', {
+  get: () ->
+    "#{@part.num}-#{@num}"
+}
+Object.defineProperty Log.Dom.Paragraph::, 'element', {
+  set: (element) ->
+    child = element.firstChild
+    (span.element = child = child.nextSibling) for span in @spans.content
+}
+Object.defineProperty Log.Dom.Paragraph::, 'element', {
+  get: () ->
+    @spans.first.element.parentNode
+}
+Object.defineProperty Log.Dom.Paragraph::, 'tail', {
+  get: () ->
+    parent = @element.parentNode
+    next = @
+    tail = []
+    tail.push(next) while (next = next.next) && !next.fold && next.element?.parentNode == parent
+    tail
+}
 
 
 Log.Dom.Spans = (parent, string) ->
@@ -218,8 +234,8 @@ $.extend Log.Dom.Spans.prototype,
   remove: (span) ->
     @content.splice(@content.indexOf(span), 1)
 
-Log.Dom.Spans::__defineGetter__ 'first', -> @content[0]
-Log.Dom.Spans::__defineGetter__ 'last',  -> @content[@.length - 1]
+Object.defineProperty Log.Dom.Spans::, 'first', { get: () -> @content[0] }
+Object.defineProperty Log.Dom.Spans::, 'last',  { get: () -> @content[@.length - 1] }
 
 
 Log.Dom.Span = (parent, num, data) ->
@@ -258,13 +274,21 @@ $.extend Log.Dom.Span.prototype,
     siblings
   trigger: ->
     @parent.trigger.apply(@parent, arguments)
-Log.Dom.Span::__defineGetter__ 'head', ->
-  @siblings('prev')
-Log.Dom.Span::__defineGetter__ 'tail', ->
-  @siblings('next')
-Log.Dom.Span::__defineGetter__ 'prev', ->
-  span = @parent.spans.at(@parent.spans.indexOf(@) - 1)
-  span || @parent.prev?.spans?.last
-Log.Dom.Span::__defineGetter__ 'next', ->
-  span = @parent.spans.at(@parent.spans.indexOf(@) + 1)
-  span || @parent.next?.spans?.first
+Object.defineProperty Log.Dom.Span::, 'head', {
+  get: () ->
+    @siblings('prev')
+}
+Object.defineProperty Log.Dom.Span::, 'tail', {
+  get: () ->
+    @siblings('next')
+}
+Object.defineProperty Log.Dom.Span::, 'prev', {
+  get: () ->
+    span = @parent.spans.at(@parent.spans.indexOf(@) - 1)
+    span || @parent.prev?.spans?.last
+}
+Object.defineProperty Log.Dom.Span::, 'next', {
+  get: () ->
+    span = @parent.spans.at(@parent.spans.indexOf(@) + 1)
+    span || @parent.next?.spans?.first
+}

--- a/lib/log.old/engine/dom2.coffee
+++ b/lib/log.old/engine/dom2.coffee
@@ -37,14 +37,18 @@ $.extend Log.Dom.prototype,
 #     @engine.parts.splice(@num, 1)
 #   # trigger: ->
 #   #   @engine.trigger.apply(@engine, arguments)
-# Log.Dom.Part::__defineGetter__ 'prev', ->
-#   num  = @num
-#   prev = @engine.parts[num -= 1] until prev || num < 0
-#   prev
-# Log.Dom.Part::__defineGetter__ 'next', ->
-#   num  = @num
-#   next = @engine.parts[num += 1] until next || num >= @engine.parts.length
-#   next
+# Object.defineProperty Log.Dom.Part::, 'prev', {
+#   get: () ->
+#     num  = @num
+#     prev = @engine.parts[num -= 1] until prev || num < 0
+#     prev
+# }
+# Object.defineProperty Log.Dom.Part::, 'next', {
+#   get: () ->
+#     num  = @num
+#     next = @engine.parts[num += 1] until next || num >= @engine.parts.length
+#     next
+# }
 
 
 Log.Dom.Nodes = (parent) ->
@@ -61,9 +65,15 @@ $.extend Log.Dom.Nodes.prototype,
     @content.splice(@content.indexOf(node), 1)
     # @parent.remove() if @content.length == 0
 
-Log.Dom.Nodes::__defineGetter__ 'length', -> @content.length
-Log.Dom.Nodes::__defineGetter__ 'first',  -> @content[0]
-Log.Dom.Nodes::__defineGetter__ 'last',   -> @content[@content.length - 1]
+Object.defineProperty Log.Dom.Nodes::, 'length', {
+  get: () -> @content.length
+}
+Object.defineProperty Log.Dom.Nodes::, 'first', {
+  get: () -> @content[0]
+}
+Object.defineProperty Log.Dom.Nodes::, 'last', {
+  get: () -> @content[@content.length - 1]
+}
 
 Log.Dom.Node = ->
 $.extend Log.Dom.Node,
@@ -79,16 +89,20 @@ $.extend Log.Dom.Node,
   #   node.remove() for node in nodes
   #   node.parent.nodes.insert(node) for node in nodes
   #   console.log document.firstChild.innerHTML.replace(/<\/p>/gm, '</p>\n') + '\n'
-Log.Dom.Node::__defineGetter__ 'prev', ->
-  num = @num
-  # console.log @parent
-  # console.log [@id, @num, (@parent.nodes.content.map (n) -> n.id), @parent.prev?.id, @parent.prev?.nodes.last]
-  prev = @parent.nodes.at(num -= 1) until prev || num < 0
-  prev || @parent.prev?.nodes.last
-Log.Dom.Node::__defineGetter__ 'next', ->
-  num = @num
-  next = @parent.nodes.at(num += 1) until next || num >= @parent.nodes.length
-  next || @parent.next?.nodes.first
+Object.defineProperty Log.Dom.Node::, 'prev', {
+  get: () ->
+    num = @num
+    # console.log @parent
+    # console.log [@id, @num, (@parent.nodes.content.map (n) -> n.id), @parent.prev?.id, @parent.prev?.nodes.last]
+    prev = @parent.nodes.at(num -= 1) until prev || num < 0
+    prev || @parent.prev?.nodes.last
+}
+Object.defineProperty Log.Dom.Node::, 'next', {
+  get: () ->
+    num = @num
+    next = @parent.nodes.at(num += 1) until next || num >= @parent.nodes.length
+    next || @parent.next?.nodes.first
+}
 
 
 # Log.Dom.Fold = (parent, num, event, name) ->
@@ -180,19 +194,27 @@ Log.Dom.Paragraph.prototype = $.extend new Log.Dom.Node,
   # trigger: ->
   #   @parent.trigger.apply(@parent, arguments)
 
-Log.Dom.Paragraph::__defineGetter__ 'id', ->
-  "#{@parent.num}-#{@num}"
-# Log.Dom.Paragraph::__defineSetter__ 'element', (element) ->
-#   child = element.firstChild
-#   (span.element = child = child.nextSibling) for span in @spans.content
-# Log.Dom.Paragraph::__defineGetter__ 'element', ->
-#   @spans.first.element.parentNode
-# Log.Dom.Paragraph::__defineGetter__ 'tail', ->
-#   parent = @element.parentNode
-#   next = @
-#   tail = []
-#   tail.push(next) while (next = next.next) && !next.fold && next.element?.parentNode == parent
-#   tail
+Object.defineProperty Log.Dom.Paragraph::, 'id', {
+  get: () ->
+    "#{@parent.num}-#{@num}"
+}
+# Object.defineProperty Log.Dom.Paragraph::, 'element', {
+#   set: (element) ->
+#     child = element.firstChild
+#     (span.element = child = child.nextSibling) for span in @spans.content
+# }
+# Object.defineProperty Log.Dom.Paragraph::, 'element', {
+#   get: () ->
+#     @spans.first.element.parentNode
+# }
+# Object.defineProperty Log.Dom.Paragraph::, 'tail', {
+#   get: () ->
+#     parent = @element.parentNode
+#     next = @
+#     tail = []
+#     tail.push(next) while (next = next.next) && !next.fold && next.element?.parentNode == parent
+#     tail
+# }
 
 
 Log.Dom.Spans = (parent, ids, string) ->
@@ -224,8 +246,8 @@ $.extend Log.Dom.Spans.prototype,
   remove: (span) ->
     @content.splice(@content.indexof(span), 1)
 
-Log.Dom.Spans::__defineGetter__ 'first', -> @content[0]
-Log.Dom.Spans::__defineGetter__ 'last',  -> @content[@content.length - 1]
+Object.defineProperty Log.Dom.Spans::, 'first', { get: () -> @content[0] }
+Object.defineProperty Log.Dom.Spans::, 'last',  { get: () -> @content[@content.length - 1] }
 
 
 Log.Dom.Span = (parent, ids, data) ->
@@ -264,22 +286,32 @@ $.extend Log.Dom.Span.prototype,
   #   siblings
   # trigger: ->
   #   @parent.trigger.apply(@parent, arguments)
-# Log.Dom.Span::__defineGetter__ 'head', ->
-#   @siblings('prev')
-# Log.Dom.Span::__defineGetter__ 'tail', ->
-#   @siblings('next')
+# Object.defineProperty Log.Dom.Span::, 'head', {
+#   get: () ->
+#     @siblings('prev')
+# }
+# Object.defineProperty Log.Dom.Span::, 'tail', {
+#   get: () ->
+#     @siblings('next')
+# }
 
-Log.Dom.Span::__defineGetter__ 'prev', ->
-  console.log @num
-  span = @parent.spans.at(@num - 1)
-  span || @parent.prev?.spans?.last
+Object.defineProperty Log.Dom.Span::, 'prev', {
+  get: () ->
+    console.log @num
+    span = @parent.spans.at(@num - 1)
+    span || @parent.prev?.spans?.last
+}
 
-# Log.Dom.Span::__defineGetter__ 'prev', ->
-#   span = @parent.spans.at(@parent.spans.indexOf(@) - 1)
-#   span || @parent.prev?.spans?.last
-# Log.Dom.Span::__defineGetter__ 'next', ->
-#   span = @parent.spans.at(@parent.spans.indexOf(@) + 1)
-#   span || @parent.next?.spans?.first
+# Object.defineProperty Log.Dom.Span::, 'prev', {
+#   get: () ->
+#     span = @parent.spans.at(@parent.spans.indexOf(@) - 1)
+#     span || @parent.prev?.spans?.last
+# }
+# Object.defineProperty Log.Dom.Span::, 'next', {
+#   get: () ->
+#     span = @parent.spans.at(@parent.spans.indexOf(@) + 1)
+#     span || @parent.next?.spans?.first
+# }
 
 
 

--- a/lib/log.old/folds.coffee
+++ b/lib/log.old/folds.coffee
@@ -23,10 +23,13 @@ $.extend Log.Folds.Fold.prototype,
     # add a class that adds the fold expand/collapse icon only if we have children
     @fold.setAttribute('class', @fold.getAttribute('class') + ' fold')
     @active = true
-Log.Folds.Fold::__defineGetter__ 'fold', ->
-  @_fold ||= document.getElementById(@start)
-Log.Folds.Fold::__defineGetter__ 'nodes', ->
-  node = @fold
-  nodes = []
-  nodes.push(node) while (node = node.nextSibling) && node.id != @end
-  nodes
+Object.defineProperty Log.Folds.Fold::, 'fold', {
+  get: () -> @_fold ||= document.getElementById(@start)
+}
+Object.defineProperty Log.Folds.Fold::, 'nodes', {
+  get: () ->
+    node = @fold
+    nodes = []
+    nodes.push(node) while (node = node.nextSibling) && node.id != @end
+    nodes
+}

--- a/lib/log.old/limit.coffee
+++ b/lib/log.old/limit.coffee
@@ -7,7 +7,7 @@ Log.Limit.prototype = $.extend new Log.Listener,
   insert: (log, line, pos) ->
     @count += 1 if line.type == 'paragraph' && !line.hidden
 
-Log.Limit::__defineGetter__ 'limited', ->
-  @count >= @max_lines
-
+Object.defineProperty Log.Limit::, 'limited', {
+  get: () -> @count >= @max_lines
+}
 

--- a/spec/helpers/jsdom.coffee
+++ b/spec/helpers/jsdom.coffee
@@ -6,11 +6,13 @@ eval require('fs').readFileSync('vendor/jsdom-browser-domtohtml.js', 'utf-8')
 HTMLEncode = exports.HTMLEncode
 domToHtml  = exports.domToHtml
 
-core.Element.prototype.__defineGetter__ 'innerHTML', ->
-  if /^(?:script|style)$/.test(this._tagName)
-    type = @getAttribute('type')
-    if !type || /^text\//i.test(type) || /\/javascript$/i.test(type)
-      domToHtml(this._childNodes, true, true)
-  domToHtml(this._childNodes, true)
+Object.defineProperty core.Element::, 'innerHTML', {
+  get: () ->
+    if /^(?:script|style)$/.test(this._tagName)
+      type = @getAttribute('type')
+      if !type || /^text\//i.test(type) || /\/javascript$/i.test(type)
+        domToHtml(this._childNodes, true, true)
+    domToHtml(this._childNodes, true)
+}
 
 exports.Document = core.Document

--- a/spec/helpers/jsdom.js
+++ b/spec/helpers/jsdom.js
@@ -13,15 +13,17 @@
 
   domToHtml = exports.domToHtml;
 
-  core.Element.prototype.__defineGetter__('innerHTML', function() {
-    var type;
-    if (/^(?:script|style)$/.test(this._tagName)) {
-      type = this.getAttribute('type');
-      if (!type || /^text\//i.test(type) || /\/javascript$/i.test(type)) {
-        domToHtml(this._childNodes, true, true);
+  Object.defineProperty(core.Element.prototype, 'innerHTML', {
+    get: function() {
+      var type;
+      if (/^(?:script|style)$/.test(this._tagName)) {
+        type = this.getAttribute('type');
+        if (!type || /^text\//i.test(type) || /\/javascript$/i.test(type)) {
+          domToHtml(this._childNodes, true, true);
+        }
       }
+      return domToHtml(this._childNodes, true);
     }
-    return domToHtml(this._childNodes, true);
   });
 
   exports.Document = core.Document;


### PR DESCRIPTION
**defineSetter** is not standardized and not supported in IE.

This basically does the same for the files in lib/log.old/ and spec/helpers than #1 and #2 did for the "main" files. I file this separately as I don't know what the purpose of these files is, i.e., why they are still in the repo.
