### PR TITLE
added required `bundle install` command to readme. use 'http://rubygems....

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'thin'
 gem 'sinatra'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+At first, you need to install all the required dependencies:
+```
+bundle install
+```
+
 build:
 
 ```


### PR DESCRIPTION
...org' in Gemfile.

first time I used ruby and installed a project. therefore with this pr you can find all infos which were required to get it running but were not yet documented.

ruby tolled me that `:rubygems` is deprecated, therefore I changed it to the recommended way I was told by the cli tool.
