### PR TITLE
Fixed error in IE that prevents logs from showing

### DIFF
--- a/lib/log/renderer.coffee
+++ b/lib/log/renderer.coffee
@@ -88,7 +88,7 @@ Log.extend Log.Renderer.prototype,
 
   createSpan: ->
     span = document.createElement('span')
-    span.appendChild(document.createTextNode(''))
+    span.appendChild(document.createTextNode(' '))
     span
 
   insertBefore: (node, other) ->


### PR DESCRIPTION
IE doesn't clone completely empty text nodes on `cloneNode(true)`, see http://jsfiddle.net/SFqk9 for an example.
This results in a null reference exception when setting `span.lastChild.nodeValue` in the `renderSpan` function. By putting a space char in the text node this doesn't happen as the node gets cloned correctly.

With this change, the logs show up correctly in IE:
![logs](https://f.cloud.github.com/assets/1376924/1910467/f9340166-7d17-11e3-8e70-9a006a338e99.png)
